### PR TITLE
Fix csrf referer issue when using cloudfront + gov uk paas

### DIFF
--- a/help/settings/prod.py
+++ b/help/settings/prod.py
@@ -6,6 +6,10 @@ ALLOWED_HOSTS = [
     'enav-help.cloudapps.digital'
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    'contact-us.export.great.gov.uk'
+]
+
 INSTALLED_APPS += [
     'raven.contrib.django.raven_compat'
 ]

--- a/help/settings/staging.py
+++ b/help/settings/staging.py
@@ -6,6 +6,10 @@ ALLOWED_HOSTS = [
     'enav-help-staging.cloudapps.digital'
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    'contact-us.export.staging.uktrade.io'
+]
+
 INSTALLED_APPS += [
     'raven.contrib.django.raven_compat'
 ]


### PR DESCRIPTION
The referer header must be white listed in cloudfront for this fix to work.

